### PR TITLE
Update GitHub owner references after account rename

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,4 @@
 # These are supported funding model platforms
 
-github: [lowrollr]
+github: [jcbmrshll]
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 title: "turbozero: fast + parallel AlphaZero"
 abstract: vectorized implementation of AlphaZero/MCTS with training and evaluation utilities
-url: "https://github.com/lowrollr/turbozero"
+url: "https://github.com/jcbmrshll/turbozero"
 authors:
 - family-names: "Marshall" 
   given-names: "Jacob"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # *turbozero* 🏎️ 🏎️ 🏎️ 🏎️
 
-📣 If you're looking for the old PyTorch version of turbozero, it's been moved here: [turbozero_torch](https://github.com/lowrollr/turbozero_torch) 📣
+📣 If you're looking for the old PyTorch version of turbozero, it's been moved here: [turbozero_torch](https://github.com/jcbmrshll/turbozero_torch) 📣
 
 #### *`turbozero`* is a vectorized implementation of [AlphaZero](https://deepmind.google/discover/blog/alphazero-shedding-new-light-on-chess-shogi-and-go/) written in JAX
 
@@ -16,13 +16,13 @@ It contains:
 
 #### *`turbozero`* is *_extendable_*:
  * see an [idea on twitter](https://twitter.com/ptrschmdtnlsn/status/1748800529608888362) for a simple tweak to MCTS?
-      * [implement it](https://github.com/lowrollr/turbozero/blob/main/core/evaluators/mcts/weighted_mcts.py) then [test it](https://github.com/lowrollr/turbozero/blob/main/notebooks/weighted_mcts.ipynb) by extending core components
+      * [implement it](https://github.com/jcbmrshll/turbozero/blob/main/core/evaluators/mcts/weighted_mcts.py) then [test it](https://github.com/jcbmrshll/turbozero/blob/main/notebooks/weighted_mcts.ipynb) by extending core components
   
 #### *`turbozero`* is *_flexible_*:
  * easy to integrate with you custom JAX environment or neural network architecture.
  * Use the provided training and evaluation utilities, or pick and choose the components that you need.
 
-To get started, check out the [Hello World Notebook](https://github.com/lowrollr/turbozero/blob/main/notebooks/hello_world.ipynb)
+To get started, check out the [Hello World Notebook](https://github.com/jcbmrshll/turbozero/blob/main/notebooks/hello_world.ipynb)
 
 ## Installation
 `turbozero` uses `poetry` for dependency management, you can install it with:
@@ -53,10 +53,10 @@ poetry run python -m ipykernel install --user --name turbozero
 ```
 
 ## Issues
-If you use this project and encounter an issue, error, or undesired behavior, please submit a [GitHub Issue](https://github.com/lowrollr/turbozero/issues) and I will do my best to resolve it as soon as I can. You may also contact me directly via `hello@jacob.land`.
+If you use this project and encounter an issue, error, or undesired behavior, please submit a [GitHub Issue](https://github.com/jcbmrshll/turbozero/issues) and I will do my best to resolve it as soon as I can. You may also contact me directly via `hello@jacob.land`.
 
 ## Contributing 
-Contributions, improvements, and fixes are more than welcome! For now I don't have a formal process for this, other than creating a [Pull Request](https://github.com/lowrollr/turbozero/pulls). For large changes, consider creating an [Issue](https://github.com/lowrollr/turbozero/issues) beforehand.
+Contributions, improvements, and fixes are more than welcome! For now I don't have a formal process for this, other than creating a [Pull Request](https://github.com/jcbmrshll/turbozero/pulls). For large changes, consider creating an [Issue](https://github.com/jcbmrshll/turbozero/issues) beforehand.
 
 If you are interested in contributing but don't know what to work on, please reach out. I have plenty of things you could do.
 
@@ -80,6 +80,6 @@ If you found this work useful, please cite it with:
 @software{turbozero,
   author = {Marshall, Jacob},
   title = {{turbozero: fast + parallel AlphaZero}},
-  url = {https://github.com/lowrollr/turbozero}
+  url = {https://github.com/jcbmrshll/turbozero}
 }
 ```

--- a/notebooks/weighted_mcts.ipynb
+++ b/notebooks/weighted_mcts.ipynb
@@ -42,12 +42,12 @@
    "source": [
     "Weighted MCTS: https://twitter.com/ptrschmdtnlsn/status/1748800529608888362\n",
     "\n",
-    "Implemented here: https://github.com/lowrollr/turbozero/blob/main/core/evaluators/mcts/weighted_mcts.py\n",
+    "Implemented here: https://github.com/jcbmrshll/turbozero/blob/main/core/evaluators/mcts/weighted_mcts.py\n",
     "\n",
     "temperature controlled by `q_temperature` (passed to AlphaZero initialization below)\n",
     "\n",
-    "For more on turbozero, see the [README](https://github.com/lowrollr/turbozero) and \n",
-    "[Hello World notebook](https://github.com/lowrollr/turbozero/blob/main/notebooks/hello_world.ipynb). The hello world notebook explains each component we set up in this notebook!\n"
+    "For more on turbozero, see the [README](https://github.com/jcbmrshll/turbozero) and \n",
+    "[Hello World notebook](https://github.com/jcbmrshll/turbozero/blob/main/notebooks/hello_world.ipynb). The hello world notebook explains each component we set up in this notebook!\n"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "turbozero"
 version = "0.1.1"
 description = "vectorized alphazero/mcts in JAX"
-authors = ["lowrollr <92640744+lowrollr@users.noreply.github.com>"]
+authors = ["jcbmrshll <92640744+jcbmrshll@users.noreply.github.com>"]
 license = "Apache-2.0"
 readme = "README.md"
 packages = [


### PR DESCRIPTION
The GitHub account owning this repo was renamed `lowrollr` → `jcbmrshll` (account ID 92640744 unchanged). GitHub's rename redirect currently keeps old URLs alive, but that redirect dies the moment anyone registers the old username — so every in-repo reference is updated here.

## Changes
- **README.md** — all `github.com/lowrollr/...` links, including the sibling repo `turbozero_torch` (which moved with the account), plus the citation block URL.
- **CITATION.cff** — `url:` field.
- **pyproject.toml** — `authors` name and the noreply email's name part (`92640744+jcbmrshll@…`). Cosmetic: the numeric ID is what actually routes mail, so this was non-breaking either way.
- **.github/FUNDING.yml** — `github: [jcbmrshll]`.
- **notebooks/weighted_mcts.ipynb** — three markdown-source URLs. Only the URL strings changed; JSON validity confirmed, and no cell formatting, execution counts, or outputs were touched.

`grep -rn -i lowrollr . --exclude-dir=.git` now returns nothing. The git remote was already re-pointed and was not modified.

## Notes on external references
- The prompt mentioned a sibling repo `lowrollr/mctx-az` — there is no reference to it anywhere in this repo (the only mctx link is to `google-deepmind/mctx`), so nothing to change.
- **Possible external publication:** `pyproject.toml` declares the package `turbozero` v0.1.1, which suggests a **PyPI** release whose project metadata/homepage may still point at the old owner. `CITATION.cff` also exists, which is what Zenodo/GitHub citation tooling reads — if this repo was ever archived to **Zenodo for a DOI**, that record's URL would need updating too. Neither can be fixed from inside this repo; flagging for manual follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)